### PR TITLE
Claude Code用のGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,9 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+    types: [opened]
 
 jobs:
   claude-response:
@@ -21,11 +19,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2.11"
 
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## Summary
- Claude Code用のGitHub Actionsワークフローを追加
- 公式ドキュメントの推奨設定に準拠

## 変更内容
- `@claude`メンションでClaude Codeが自動応答
- トリガー: issue_comment, pull_request_review_comment, issues (opened)
- 必要最小限のpermissionsを設定

## Test plan
- [ ] PRやIssueで`@claude`とメンションして動作確認
- [ ] ANTHROPIC_API_KEYがシークレットに設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)