### PR TITLE
GitHub Issues管理体制を構築しJIRAから移行

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: "バグ報告"
+description: "バグを報告する"
+labels: ["type/bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "バグの内容"
+      description: "何が起きているか"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: "再現手順"
+      description: "バグを再現する手順"
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "期待する動作"
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: "実際の動作"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: "対象エリア"
+      options:
+        - frontend
+        - backend
+        - db
+        - auth
+        - ui
+        - infra
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: "補足情報"
+      description: "スクリーンショット、ログなど"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,38 @@
+name: "機能リクエスト"
+description: "新しい機能を提案する"
+labels: ["type/feature"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "概要"
+      description: "どんな機能か"
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "背景・モチベーション"
+      description: "なぜこの機能が必要か"
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: "詳細"
+      description: "実装イメージや受け入れ条件"
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: "対象エリア"
+      options:
+        - frontend
+        - backend
+        - db
+        - auth
+        - ui
+        - infra
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,24 @@
+name: "調査・検証"
+description: "調査や技術検証を行う"
+labels: ["type/spike"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: "調査事項"
+      description: "何を調査・検証するか"
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: "ゴール"
+      description: "調査完了の条件（ドキュメント、PoC等）"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: "背景・参考情報"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,29 @@
+name: "タスク"
+description: "開発タスク・改善作業"
+labels: ["type/task"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "タスク内容"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "完了条件"
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: "対象エリア"
+      options:
+        - frontend
+        - backend
+        - db
+        - auth
+        - ui
+        - infra
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-## チケットへのリンク
+## 関連Issue
 
-<!-- チケットの番号を追加(RIBON-チケット番号) -->
+<!-- Issue番号を記載（例: Close #123） -->
 
-- [該当チケット](https://nikawa2161t.atlassian.net/browse/RIBON-番号)
+- Close #
 
 ## やったこと
 


### PR DESCRIPTION
## Summary
- Issueテンプレート追加（バグ・機能・タスク・調査の4種類）
- PRテンプレートをJIRAリンクからGitHub Issue参照（Close #番号）に変更
- blank issueを無効化し、テンプレート経由での作成を強制

## Test plan
- [ ] GitHub上でIssue作成画面を開き、4種類のテンプレートが表示されることを確認
- [ ] PRテンプレートがGitHub Issue参照形式になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)